### PR TITLE
fix erroneous seeking on props update

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -74,6 +74,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     private ReactExoplayerConfig config;
 
+    private float lastSeekPosition = Float.NaN;
+
     public ReactExoplayerViewManager(ReactExoplayerConfig config) {
         this.config = config;
     }
@@ -270,7 +272,10 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SEEK)
     public void setSeek(final ReactExoplayerView videoView, final float seek) {
-        videoView.seekTo(Math.round(seek * 1000f));
+        if (seek != lastSeekPosition) {
+            lastSeekPosition = seek;
+            videoView.seekTo(Math.round(seek * 1000f));
+        }
     }
 
     @ReactProp(name = PROP_RATE)


### PR DESCRIPTION
with the new arch, we're seeing native view props setters being called even if the prop itself hasn't changed (e.g., discord/react-native-slider#2)

this is problematic for props like `seek` which make the component semi-controlled: we update the component whenever the prop changes, but allow the true value (i.e., playback position) to diverge as long as the prop remains the same

in an ideal world, seeking is implemented as an imperative function rather than a declarative prop, but for now, we can patch the buggy behavior by comparing against the last set value