### PR TITLE
[android] Fix MediaCodec exhaustion crashes for quest bar videos

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -27,7 +27,11 @@ export default class Video extends Component {
   }
 
   setNativeProps(nativeProps) {
-    this._root.setNativeProps(nativeProps);
+    if (this._root && this._root.setNativeProps) {
+      this._root.setNativeProps(nativeProps);
+    } else {
+      console.warn('Video component not ready for setNativeProps call');
+    }
   }
 
   toTypeString(x) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -260,6 +260,13 @@ class ReactExoplayerView extends FrameLayout implements
             return;
         }
         setPlayWhenReady(false);
+        if (player != null) {
+            try {
+                player.stop();
+            } catch (Exception e) {
+                // Ignore stop errors
+            }
+        }
     }
 
     @Override
@@ -533,7 +540,12 @@ class ReactExoplayerView extends FrameLayout implements
     private void releasePlayer() {
         if (player != null) {
             updateResumePosition();
-            player.release();
+            try {
+                player.stop();
+                player.release();
+            } catch (Exception e) {
+                // Ignore release errors to prevent crash loops
+            }
             ReactExoplayerView self = this;
             player.removeListener(self);
             trackSelector = null;
@@ -925,6 +937,14 @@ class ReactExoplayerView extends FrameLayout implements
         String errorString = "PlaybackException type : " + exoException.type;
         if (exoException.type == ExoPlaybackException.TYPE_RENDERER) {
             Exception cause = exoException.getRendererException();
+            
+            if (cause != null && cause.getMessage() != null && 
+                cause.getMessage().contains("MediaCodecVideoRenderer")) {
+                releasePlayer();
+                initializePlayer();
+                return;
+            }
+            
             if (cause instanceof MediaCodecRenderer.DecoderInitializationException) {
                 // Special case for decoder initialization failures.
                 MediaCodecRenderer.DecoderInitializationException decoderInitializationException =


### PR DESCRIPTION
Resolves Android crashes caused by repeated quest bar interactions that exhaust MediaCodec resources. Addresses production issue where 14% of Android users experienced crashes with OMX.Exynos.avc.dec decoder failures.

Changes:
- Force player.stop() before release() to ensure proper MediaCodec cleanup
- Add MediaCodec cleanup on onHostPause() for quest bar interactions
- Add null safety for setNativeProps to prevent "Cannot read property" errors
- Implement MediaCodec error recovery with player recreation
