### PR TITLE
[ios] Remove unused AVPlayerItemNewAccessLogEntry observer

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -780,13 +780,6 @@ static int const RCTVideoUnset = -1;
                                              object:nil];
   
   [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                  name:AVPlayerItemNewAccessLogEntryNotification
-                                                object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleAVPlayerAccess:)
-                                               name:AVPlayerItemNewAccessLogEntryNotification
-                                             object:nil];
-  [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name: AVPlayerItemFailedToPlayToEndTimeNotification
                                                 object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -796,16 +789,6 @@ static int const RCTVideoUnset = -1;
   
 }
 
-- (void)handleAVPlayerAccess:(NSNotification *)notification {
-  AVPlayerItemAccessLog *accessLog = [((AVPlayerItem *)notification.object) accessLog];
-  AVPlayerItemAccessLogEvent *lastEvent = accessLog.events.lastObject;
-  
-  /* TODO: get this working
-   if (self.onBandwidthUpdate) {
-   self.onBandwidthUpdate(@{@"bitrate": [NSNumber numberWithFloat:lastEvent.observedBitrate]});
-   }
-   */
-}
 
 - (void)didFailToFinishPlaying:(NSNotification *)notification {
   NSError *error = notification.userInfo[AVPlayerItemFailedToPlayToEndTimeErrorKey];


### PR DESCRIPTION
## Problem
The `handleAVPlayerAccess` method contains unused functionality (bandwidth updates are commented out with TODO) but the `AVPlayerItemNewAccessLogEntryNotification` observer was still active. This observer triggers synchronous calls to `AVPlayerItem.accessLog` which can block the main thread for extended periods during video playback, causing iOS app hangs.

## Solution
- Remove the notification observer registration for `AVPlayerItemNewAccessLogEntryNotification`
- Remove the unused `handleAVPlayerAccess` method

## Benefits
- Eliminates potential main thread blocking during video playback
- Removes dead code that serves no functional purpose

Fixes DISCORD-IOS-HBTR