### PR TITLE
[android] Fix ExoPlayer threading crash in audio focus callback

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -671,7 +671,12 @@ class ReactExoplayerView extends FrameLayout implements
             case AudioManager.AUDIOFOCUS_LOSS:
                 this.hasAudioFocus = false;
                 eventEmitter.audioFocusChanged(false);
-                pausePlayback();
+                mainHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        pausePlayback();
+                    }
+                });
                 audioManager.abandonAudioFocus(this);
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
@@ -689,12 +694,26 @@ class ReactExoplayerView extends FrameLayout implements
             if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
                 // Lower the volume
                 if (!muted) {
-                    player.setVolume(audioVolume * 0.8f);
+                    mainHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (player != null) {
+                                player.setVolume(audioVolume * 0.8f);
+                            }
+                        }
+                    });
                 }
             } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
                 // Raise it back to normal
                 if (!muted) {
-                    player.setVolume(audioVolume * 1);
+                    mainHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (player != null) {
+                                player.setVolume(audioVolume * 1);
+                            }
+                        }
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Problem
Android app crashes with `IllegalStateException: Player is accessed on the wrong thread` when audio focus changes during video playback. The crash occurs in `ReactExoplayerView.onAudioFocusChange()` when calling ExoPlayer methods like `player.getPlayWhenReady()` and `player.setVolume()`.

## Root Cause
`AudioManager.OnAudioFocusChangeListener.onAudioFocusChange()` is invoked by Android on an arbitrary thread, not guaranteed to be the main thread. ExoPlayer strictly enforces that all player operations must occur on the thread where the player was created (the main thread).

## Solution
Wrap all ExoPlayer operations in `onAudioFocusChange()` with `mainHandler.post()` calls to ensure they execute on the main thread:

1. `pausePlayback()` call when audio focus is lost
2. `player.setVolume()` for volume ducking (transient focus loss)
3. `player.setVolume()` for volume restoration (focus gain)