### PR TITLE
[android] Ignore case where height & width are set to 0

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -229,6 +229,11 @@ public final class ExoPlayerView extends FrameLayout {
 
         @Override
         public void onVideoSizeChanged(VideoSize videoSize) {
+            // This avoids a case where HLS passes height & width of 0 when initialization
+            // which causes aspect ratio to be 1:1 and gets stuck.
+            if (videoSize.width == 0 && videoSize.height == 0) {
+                return;
+            }
             boolean isInitialRatio = layout.getAspectRatio() == 0;
             layout.setAspectRatio(videoSize.height == 0 ? 1 : (videoSize.width * videoSize.pixelWidthHeightRatio) / videoSize.height);
 


### PR DESCRIPTION
**Description**
For video quests on mobile, specifically android, videos were being played with the incorrect aspect ratio and were getting forced into a 1:1 aspect ratio. This only happens when we play an HLS asset and not MP4 files, this ignores the initial state where height and width are both 0.

I would prefer to always post when the video size changes, but I assume the isInitialRatio check was added either for performance or similar reason.