### PR TITLE
[android] Add httpEngine prop for configurable ExoPlayer data source

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -476,6 +476,7 @@ Video.propTypes = {
   reportBandwidth: PropTypes.bool,
   disableFocus: PropTypes.bool,
   controls: PropTypes.bool,
+  httpEngine: PropTypes.string,
   audioOnly: PropTypes.bool,
   currentTime: PropTypes.number,
   fullscreenAutorotate: PropTypes.bool,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
@@ -13,6 +13,7 @@ import com.google.android.exoplayer2.util.Util;
 
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DataSourceUtil {
@@ -24,6 +25,7 @@ public class DataSourceUtil {
     private static DataSource.Factory defaultDataSourceFactory = null;
     private static HttpDataSource.Factory defaultHttpDataSourceFactory = null;
     private static String userAgent = null;
+    private static final Map<String, DataSource.Factory> namedDataSourceFactories = new HashMap<>();
 
     public static void setUserAgent(String userAgent) {
         DataSourceUtil.userAgent = userAgent;
@@ -68,6 +70,15 @@ public class DataSourceUtil {
 
     public static void setDefaultHttpDataSourceFactory(HttpDataSource.Factory factory) {
         DataSourceUtil.defaultHttpDataSourceFactory = factory;
+    }
+
+    public static void registerDataSourceFactory(String name, DataSource.Factory factory) {
+        namedDataSourceFactories.put(name, factory);
+    }
+
+    public static DataSource.Factory getNamedDataSourceFactory(String name) {
+        DataSource.Factory factory = namedDataSourceFactories.get(name);
+        return factory != null ? factory : defaultDataSourceFactory;
     }
 
     private static DataSource.Factory buildRawDataSourceFactory(ReactContext context) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1045,9 +1045,7 @@ class ReactExoplayerView extends FrameLayout implements
             this.srcUri = uri;
             this.extension = extension;
             this.requestHeaders = headers;
-            this.mediaDataSourceFactory =
-                    DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, bandwidthMeter,
-                            this.requestHeaders);
+            this.mediaDataSourceFactory = buildDataSourceFactory(true);
 
             if (!isSourceEqual) {
                 reloadSource();
@@ -1321,6 +1319,9 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setHttpEngine(String httpEngine) {
         this.httpEngine = httpEngine;
+        if (srcUri != null) {
+            this.mediaDataSourceFactory = buildDataSourceFactory(true);
+        }
     }
 
     public void setFullscreen(boolean fullscreen) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -149,6 +149,7 @@ class ReactExoplayerView extends FrameLayout implements
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
     private Map<String, String> requestHeaders;
+    private String httpEngine = null;
     private boolean mReportBandwidth = false;
     private UUID drmUUID = null;
     private String drmLicenseUrl = null;
@@ -647,6 +648,12 @@ class ReactExoplayerView extends FrameLayout implements
      * @return A new DataSource factory.
      */
     private DataSource.Factory buildDataSourceFactory(boolean useBandwidthMeter) {
+        if (httpEngine != null && !httpEngine.isEmpty() && !httpEngine.equals("default")) {
+            DataSource.Factory namedFactory = DataSourceUtil.getNamedDataSourceFactory(httpEngine);
+            if (namedFactory != null) {
+                return namedFactory;
+            }
+        }
         return DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext,
                 useBandwidthMeter ? bandwidthMeter : null, requestHeaders);
     }
@@ -1310,6 +1317,10 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setDisableFocus(boolean disableFocus) {
         this.disableFocus = disableFocus;
+    }
+
+    public void setHttpEngine(String httpEngine) {
+        this.httpEngine = httpEngine;
     }
 
     public void setFullscreen(boolean fullscreen) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -71,6 +71,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
+    private static final String PROP_HTTP_ENGINE = "httpEngine";
 
     private ReactExoplayerConfig config;
 
@@ -321,6 +322,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
     public void setControls(final ReactExoplayerView videoView, final boolean controls) {
         videoView.setControls(controls);
+    }
+
+    @ReactProp(name = PROP_HTTP_ENGINE)
+    public void setHttpEngine(final ReactExoplayerView videoView, @Nullable final String httpEngine) {
+        videoView.setHttpEngine(httpEngine);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)


### PR DESCRIPTION
## Summary

- Add named data source factory registry to `DataSourceUtil` for per-instance HTTP engine selection
- Add `httpEngine` prop to `ReactExoplayerView` / `ReactExoplayerViewManager`
- When set to a registered name (e.g. `"okhttp"`, `"cronet"`), the view uses the corresponding factory instead of the global default

Companion to discord/discord#261491 — extends configurable HTTP engine support to react-native-video consumers (e.g. Discord Quests video player).

## Changes

**`DataSourceUtil.java`**
- `registerDataSourceFactory(name, factory)` — register a named factory
- `getNamedDataSourceFactory(name)` — look up by name, falls back to default

**`ReactExoplayerView.java`**
- `httpEngine` field and setter
- `buildDataSourceFactory()` checks for named factory before using default

**`ReactExoplayerViewManager.java`**
- `@ReactProp(name = "httpEngine")` wired to view

**`Video.js`**
- `httpEngine: PropTypes.string` added to prop types

## Test plan

- [ ] Build Android app with changes
- [ ] Play video with `httpEngine='default'` — uses DefaultHttpDataSource
- [ ] Play video with `httpEngine='okhttp'` — uses registered OkHttp factory
- [ ] Play video with `httpEngine='cronet'` — uses registered Cronet factory
- [ ] Play video without `httpEngine` prop — uses global default (no regression)
- [ ] iOS unaffected (prop ignored)