### PR TITLE
guard configure audio, use off main queue for date/time

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -293,18 +293,22 @@ static int const RCTVideoUnset = -1;
   const Float64 duration = CMTimeGetSeconds(playerDuration);
   const Float64 currentTimeSecs = CMTimeGetSeconds(currentTime);
 
+  __weak RCTVideo *weakSelf = self;
   void (^deliverProgress)(void) = ^{
+    RCTVideo *strongSelf = weakSelf;
+    if (!strongSelf) return;
+
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTVideo_progress" object:nil userInfo:@{@"progress": [NSNumber numberWithDouble: currentTimeSecs / duration]}];
 
-    if( currentTimeSecs >= 0 && self.onVideoProgress) {
-      self.onVideoProgress(@{
+    if (currentTimeSecs >= 0 && strongSelf.onVideoProgress) {
+      strongSelf.onVideoProgress(@{
                              @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(currentTime)],
-                             @"playableDuration": [self calculatePlayableDuration],
+                             @"playableDuration": [strongSelf calculatePlayableDuration],
                              @"atValue": [NSNumber numberWithLongLong:currentTime.value],
                              @"atTimescale": [NSNumber numberWithInt:currentTime.timescale],
                              @"currentPlaybackTime": [NSNumber numberWithLongLong:currentPlaybackTime ? [@(floor([currentPlaybackTime timeIntervalSince1970] * 1000)) longLongValue] : 0],
-                             @"target": self.reactTag,
-                             @"seekableDuration": [self calculateSeekableDuration],
+                             @"target": strongSelf.reactTag,
+                             @"seekableDuration": [strongSelf calculateSeekableDuration],
                              });
     }
   };

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -54,6 +54,7 @@ static int const RCTVideoUnset = -1;
   Float64 _progressUpdateInterval;
   BOOL _controls;
   id _timeObserver;
+  dispatch_queue_t _progressQueue;
   
   /* Keep track of any modifiers, need to be applied after each play */
   float _volume;
@@ -193,9 +194,17 @@ static int const RCTVideoUnset = -1;
   const Float64 progressUpdateIntervalMS = _progressUpdateInterval / 1000;
   // @see endScrubbing in AVPlayerDemoPlaybackViewController.m
   // of https://developer.apple.com/library/ios/samplecode/AVPlayerDemo/Introduction/Intro.html
+
+  // Use a background queue so sendProgressUpdate can call AVPlayer/AVPlayerItem
+  // methods (e.g. currentDate) that may block on internal dispatch_sync without
+  // stalling the main thread. This is safe because removePlayerTimeObserver
+  // (called during teardown) guarantees no further callbacks after it returns.
+  if (!_progressQueue) {
+    _progressQueue = dispatch_queue_create("com.discord.react-native-video.progress", DISPATCH_QUEUE_SERIAL);
+  }
   __weak RCTVideo *weakSelf = self;
   _timeObserver = [_player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(progressUpdateIntervalMS, NSEC_PER_SEC)
-                                                        queue:NULL
+                                                        queue:_progressQueue
                                                    usingBlock:^(CMTime time) { [weakSelf sendProgressUpdate]; }
                    ];
 }
@@ -268,30 +277,35 @@ static int const RCTVideoUnset = -1;
   if (video == nil || video.status != AVPlayerItemStatusReadyToPlay) {
     return;
   }
-  
+
   CMTime playerDuration = [self playerItemDuration];
   if (CMTIME_IS_INVALID(playerDuration)) {
     return;
   }
-  
+
+  // WARNING: currentTime and currentDate can block for 100ms+ when VPIO is
+  // active. sendProgressUpdate must stay off the main thread (see _progressQueue
+  // in addPlayerTimeObserver). Event delivery is dispatched back to main below.
   CMTime currentTime = _player.currentTime;
   NSDate *currentPlaybackTime = _player.currentItem.currentDate;
   const Float64 duration = CMTimeGetSeconds(playerDuration);
   const Float64 currentTimeSecs = CMTimeGetSeconds(currentTime);
-  
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTVideo_progress" object:nil userInfo:@{@"progress": [NSNumber numberWithDouble: currentTimeSecs / duration]}];
-  
-  if( currentTimeSecs >= 0 && self.onVideoProgress) {
-    self.onVideoProgress(@{
-                           @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(currentTime)],
-                           @"playableDuration": [self calculatePlayableDuration],
-                           @"atValue": [NSNumber numberWithLongLong:currentTime.value],
-                           @"atTimescale": [NSNumber numberWithInt:currentTime.timescale],
-                           @"currentPlaybackTime": [NSNumber numberWithLongLong:[@(floor([currentPlaybackTime timeIntervalSince1970] * 1000)) longLongValue]],
-                           @"target": self.reactTag,
-                           @"seekableDuration": [self calculateSeekableDuration],
-                           });
-  }
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTVideo_progress" object:nil userInfo:@{@"progress": [NSNumber numberWithDouble: currentTimeSecs / duration]}];
+
+    if( currentTimeSecs >= 0 && self.onVideoProgress) {
+      self.onVideoProgress(@{
+                             @"currentTime": [NSNumber numberWithFloat:CMTimeGetSeconds(currentTime)],
+                             @"playableDuration": [self calculatePlayableDuration],
+                             @"atValue": [NSNumber numberWithLongLong:currentTime.value],
+                             @"atTimescale": [NSNumber numberWithInt:currentTime.timescale],
+                             @"currentPlaybackTime": [NSNumber numberWithLongLong:currentPlaybackTime ? [@(floor([currentPlaybackTime timeIntervalSince1970] * 1000)) longLongValue] : 0],
+                             @"target": self.reactTag,
+                             @"seekableDuration": [self calculateSeekableDuration],
+                             });
+    }
+  });
 }
 
 /*!
@@ -1054,6 +1068,9 @@ static int const RCTVideoUnset = -1;
 
 - (void)configureAudio
 {
+    // Muted videos don't need to touch the audio session.
+    if (_muted) return;
+
     AVAudioSession *session = [AVAudioSession sharedInstance];
     AVAudioSessionCategory category = nil;
     // This is no longer an object, but an int, that can't be cast
@@ -1084,7 +1101,7 @@ static int const RCTVideoUnset = -1;
       NSString *effectiveCategory = category ?: session.category;
       // Clear mix/duck bits before applying the new one so switching between
       // "mix" and "duck" replaces rather than accumulates.
-      // 
+      //
       // Other session options (e.g. AllowBluetooth) are preserved through the mask.
       // fixes a bug where a video player would overwrite options set by the voice engine, causing
       // bluetooth headsets to be unselectable during a call.
@@ -1093,11 +1110,22 @@ static int const RCTVideoUnset = -1;
       // individual components handling this will inevitably step on each other.
       AVAudioSessionCategoryOptions mixDuckMask =
           AVAudioSessionCategoryOptionMixWithOthers | AVAudioSessionCategoryOptionDuckOthers;
-      AVAudioSessionCategoryOptions mergedOptions = (session.categoryOptions & ~mixDuckMask) | options;
-      [session setCategory:effectiveCategory withOptions:mergedOptions error:nil];
+      AVAudioSessionCategoryOptions effectiveOptions = (session.categoryOptions & ~mixDuckMask) | options;
+
+      // Skip the setCategory XPC call if nothing would change. It can block the main thread
+      // and cause playback stutter ... (we've seen this very specifically when the app is set to
+      // AVAudioSessionModeVoiceChat). This guard is preventative ... ideally we wouldn't have 
+      // extra / excessive calls to this method at all, but such is life.
+      if ([session.category isEqualToString:effectiveCategory] && session.categoryOptions == effectiveOptions) {
+        return;
+      }
+      [session setCategory:effectiveCategory withOptions:effectiveOptions error:nil];
       return;
     }
 
+    if ([session.category isEqualToString:category]) {
+      return;
+    }
     [session setCategory:category error:nil];
 }
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -197,7 +197,7 @@ static int const RCTVideoUnset = -1;
   // of https://developer.apple.com/library/ios/samplecode/AVPlayerDemo/Introduction/Intro.html
 
   dispatch_queue_t queue = NULL;
-  if ([RNVVideoManager guardAudioSession]) {
+  if ([RNVVideoManager useBackgroundProgressQueue]) {
     // Use a background queue so sendProgressUpdate can call AVPlayer/AVPlayerItem
     // methods (e.g. currentDate) that may block on internal dispatch_sync without
     // stalling the main thread. This is safe because removePlayerTimeObserver
@@ -309,7 +309,7 @@ static int const RCTVideoUnset = -1;
     }
   };
 
-  if ([RNVVideoManager guardAudioSession]) {
+  if ([RNVVideoManager useBackgroundProgressQueue]) {
     // When on the background _progressQueue, dispatch back to main for event delivery.
     dispatch_async(dispatch_get_main_queue(), deliverProgress);
   } else {
@@ -1078,7 +1078,7 @@ static int const RCTVideoUnset = -1;
 
 - (void)configureAudio
 {
-    BOOL guard = [RNVVideoManager guardAudioSession];
+    BOOL guard = [RNVVideoManager optimizeConfigureAudio];
 
     // Muted videos don't need to touch the audio session.
     if (guard && _muted) return;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1,5 +1,6 @@
 #import <React/RCTConvert.h>
 #import "RCTVideo.h"
+#import "RCTVideoManager.h"
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/UIView+React.h>
@@ -195,16 +196,20 @@ static int const RCTVideoUnset = -1;
   // @see endScrubbing in AVPlayerDemoPlaybackViewController.m
   // of https://developer.apple.com/library/ios/samplecode/AVPlayerDemo/Introduction/Intro.html
 
-  // Use a background queue so sendProgressUpdate can call AVPlayer/AVPlayerItem
-  // methods (e.g. currentDate) that may block on internal dispatch_sync without
-  // stalling the main thread. This is safe because removePlayerTimeObserver
-  // (called during teardown) guarantees no further callbacks after it returns.
-  if (!_progressQueue) {
-    _progressQueue = dispatch_queue_create("com.discord.react-native-video.progress", DISPATCH_QUEUE_SERIAL);
+  dispatch_queue_t queue = NULL;
+  if ([RNVVideoManager guardAudioSession]) {
+    // Use a background queue so sendProgressUpdate can call AVPlayer/AVPlayerItem
+    // methods (e.g. currentDate) that may block on internal dispatch_sync without
+    // stalling the main thread. This is safe because removePlayerTimeObserver
+    // (called during teardown) guarantees no further callbacks after it returns.
+    if (!_progressQueue) {
+      _progressQueue = dispatch_queue_create("com.discord.react-native-video.progress", DISPATCH_QUEUE_SERIAL);
+    }
+    queue = _progressQueue;
   }
   __weak RCTVideo *weakSelf = self;
   _timeObserver = [_player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(progressUpdateIntervalMS, NSEC_PER_SEC)
-                                                        queue:_progressQueue
+                                                        queue:queue
                                                    usingBlock:^(CMTime time) { [weakSelf sendProgressUpdate]; }
                    ];
 }
@@ -283,15 +288,12 @@ static int const RCTVideoUnset = -1;
     return;
   }
 
-  // WARNING: currentTime and currentDate can block for 100ms+ when VPIO is
-  // active. sendProgressUpdate must stay off the main thread (see _progressQueue
-  // in addPlayerTimeObserver). Event delivery is dispatched back to main below.
   CMTime currentTime = _player.currentTime;
   NSDate *currentPlaybackTime = _player.currentItem.currentDate;
   const Float64 duration = CMTimeGetSeconds(playerDuration);
   const Float64 currentTimeSecs = CMTimeGetSeconds(currentTime);
 
-  dispatch_async(dispatch_get_main_queue(), ^{
+  void (^deliverProgress)(void) = ^{
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTVideo_progress" object:nil userInfo:@{@"progress": [NSNumber numberWithDouble: currentTimeSecs / duration]}];
 
     if( currentTimeSecs >= 0 && self.onVideoProgress) {
@@ -305,7 +307,15 @@ static int const RCTVideoUnset = -1;
                              @"seekableDuration": [self calculateSeekableDuration],
                              });
     }
-  });
+  };
+
+  if ([RNVVideoManager guardAudioSession]) {
+    // When on the background _progressQueue, dispatch back to main for event delivery.
+    dispatch_async(dispatch_get_main_queue(), deliverProgress);
+  } else {
+    // Already on main queue (queue:NULL), deliver inline.
+    deliverProgress();
+  }
 }
 
 /*!
@@ -1068,8 +1078,10 @@ static int const RCTVideoUnset = -1;
 
 - (void)configureAudio
 {
+    BOOL guard = [RNVVideoManager guardAudioSession];
+
     // Muted videos don't need to touch the audio session.
-    if (_muted) return;
+    if (guard && _muted) return;
 
     AVAudioSession *session = [AVAudioSession sharedInstance];
     AVAudioSessionCategory category = nil;
@@ -1114,16 +1126,16 @@ static int const RCTVideoUnset = -1;
 
       // Skip the setCategory XPC call if nothing would change. It can block the main thread
       // and cause playback stutter ... (we've seen this very specifically when the app is set to
-      // AVAudioSessionModeVoiceChat). This guard is preventative ... ideally we wouldn't have 
+      // AVAudioSessionModeVoiceChat). This guard is preventative ... ideally we wouldn't have
       // extra / excessive calls to this method at all, but such is life.
-      if ([session.category isEqualToString:effectiveCategory] && session.categoryOptions == effectiveOptions) {
+      if (guard && [session.category isEqualToString:effectiveCategory] && session.categoryOptions == effectiveOptions) {
         return;
       }
       [session setCategory:effectiveCategory withOptions:effectiveOptions error:nil];
       return;
     }
 
-    if ([session.category isEqualToString:category]) {
+    if (guard && [session.category isEqualToString:category]) {
       return;
     }
     [session setCategory:category error:nil];

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1082,10 +1082,10 @@ static int const RCTVideoUnset = -1;
 
 - (void)configureAudio
 {
-    BOOL guard = [RNVVideoManager optimizeConfigureAudio];
+    BOOL optimize = [RNVVideoManager optimizeConfigureAudio];
 
     // Muted videos don't need to touch the audio session.
-    if (guard && _muted) return;
+    if (optimize && _muted) return;
 
     AVAudioSession *session = [AVAudioSession sharedInstance];
     AVAudioSessionCategory category = nil;
@@ -1130,16 +1130,16 @@ static int const RCTVideoUnset = -1;
 
       // Skip the setCategory XPC call if nothing would change. It can block the main thread
       // and cause playback stutter ... (we've seen this very specifically when the app is set to
-      // AVAudioSessionModeVoiceChat). This guard is preventative ... ideally we wouldn't have
+      // AVAudioSessionModeVoiceChat). This optimization is preventative ... ideally we wouldn't have
       // extra / excessive calls to this method at all, but such is life.
-      if (guard && [session.category isEqualToString:effectiveCategory] && session.categoryOptions == effectiveOptions) {
+      if (optimize && [session.category isEqualToString:effectiveCategory] && session.categoryOptions == effectiveOptions) {
         return;
       }
       [session setCategory:effectiveCategory withOptions:effectiveOptions error:nil];
       return;
     }
 
-    if (guard && [session.category isEqualToString:category]) {
+    if (optimize && [session.category isEqualToString:category]) {
       return;
     }
     [session setCategory:category error:nil];

--- a/ios/Video/RCTVideoManager.h
+++ b/ios/Video/RCTVideoManager.h
@@ -3,4 +3,6 @@
 
 @interface RNVVideoManager : RCTViewManager <RCTBridgeModule>
 
++ (BOOL)guardAudioSession;
+
 @end

--- a/ios/Video/RCTVideoManager.h
+++ b/ios/Video/RCTVideoManager.h
@@ -3,6 +3,7 @@
 
 @interface RNVVideoManager : RCTViewManager <RCTBridgeModule>
 
-+ (BOOL)guardAudioSession;
+@property (class, nonatomic) BOOL optimizeConfigureAudio;
+@property (class, nonatomic) BOOL useBackgroundProgressQueue;
 
 @end

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -4,18 +4,35 @@
 #import <React/RCTUIManager.h>
 #import <AVFoundation/AVFoundation.h>
 
-static BOOL _guardAudioSession = NO;
+static BOOL _optimizeConfigureAudio = NO;
+static BOOL _useBackgroundProgressQueue = NO;
 
 @implementation RNVVideoManager
 
 RCT_EXPORT_MODULE(RNVVideo);
 
-+ (BOOL)guardAudioSession {
-    return _guardAudioSession;
++ (BOOL)optimizeConfigureAudio {
+    return _optimizeConfigureAudio;
 }
 
-RCT_EXPORT_METHOD(setGuardAudioSession:(BOOL)enabled) {
-    _guardAudioSession = enabled;
++ (void)setOptimizeConfigureAudio:(BOOL)optimizeConfigureAudio {
+    _optimizeConfigureAudio = optimizeConfigureAudio;
+}
+
++ (BOOL)useBackgroundProgressQueue {
+    return _useBackgroundProgressQueue;
+}
+
++ (void)setUseBackgroundProgressQueue:(BOOL)useBackgroundProgressQueue {
+    _useBackgroundProgressQueue = useBackgroundProgressQueue;
+}
+
+RCT_EXPORT_METHOD(setOptimizeConfigureAudio:(BOOL)enabled) {
+    _optimizeConfigureAudio = enabled;
+}
+
+RCT_EXPORT_METHOD(setUseBackgroundProgressQueue:(BOOL)enabled) {
+    _useBackgroundProgressQueue = enabled;
 }
 
 - (UIView *)view

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -4,9 +4,19 @@
 #import <React/RCTUIManager.h>
 #import <AVFoundation/AVFoundation.h>
 
+static BOOL _guardAudioSession = NO;
+
 @implementation RNVVideoManager
 
 RCT_EXPORT_MODULE(RNVVideo);
+
++ (BOOL)guardAudioSession {
+    return _guardAudioSession;
+}
+
+RCT_EXPORT_METHOD(setGuardAudioSession:(BOOL)enabled) {
+    _guardAudioSession = enabled;
+}
 
 - (UIView *)view
 {


### PR DESCRIPTION
The overall impact of this PR prevents video playback stalls while the iOS app is in voice or video chat mode.

NOTE: The below fixes are gated behind flags so we can measure the impact.

- Uses a non-main queue to pull current date and time, preventing main thread blocking.
- fixes configureAudio such that applying the existing settings is a no-op.
- fixes configureAudio to be a no-op if muted. if unmuted, configureAudio is already being called again to set the necessary state.

Asana: https://app.asana.com/1/236888843494340/project/1207259819822686/task/1213687432782008