### PR TITLE
[android] add httpEngine prop on Android for configurable HTTP data source

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
@@ -1,5 +1,6 @@
 package com.brentvatne.exoplayer;
 
+import android.util.Log;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.network.CookieJarContainer;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
@@ -14,8 +15,11 @@ import com.google.android.exoplayer2.util.Util;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
 import java.util.Map;
+import java.util.function.Function;
 
 public class DataSourceUtil {
+
+    private static final String TAG = "DataSourceUtil";
 
     private DataSourceUtil() {
     }
@@ -23,6 +27,7 @@ public class DataSourceUtil {
     private static DataSource.Factory rawDataSourceFactory = null;
     private static DataSource.Factory defaultDataSourceFactory = null;
     private static HttpDataSource.Factory defaultHttpDataSourceFactory = null;
+    private static Function<String, DataSource.Factory> httpEngineFactoryResolver = null;
     private static String userAgent = null;
 
     public static void setUserAgent(String userAgent) {
@@ -47,6 +52,45 @@ public class DataSourceUtil {
         DataSourceUtil.rawDataSourceFactory = factory;
     }
 
+
+    public static void setHttpEngineFactoryResolver(Function<String, DataSource.Factory> resolver) {
+        httpEngineFactoryResolver = resolver;
+    }
+
+    public static DataSource.Factory getDataSourceFactory(ReactContext context, DefaultBandwidthMeter bandwidthMeter, Map<String, String> requestHeaders, String httpEngine) {
+        if (httpEngine != null && httpEngineFactoryResolver != null) {
+            DataSource.Factory factory = httpEngineFactoryResolver.apply(httpEngine);
+            if (factory != null) {
+                return factory;
+            }
+        }
+        return getDefaultDataSourceFactory(context, bandwidthMeter, requestHeaders);
+    }
+
+    /**
+     * Returns an HttpDataSource.Factory selected by the registered httpEngine resolver, or the
+     * default factory if no engine is selected, no resolver is registered, the resolver returns
+     * null, or the resolver returns a DataSource.Factory that does not implement
+     * HttpDataSource.Factory.
+     *
+     * The resolver registered via setHttpEngineFactoryResolver returns a generic DataSource.Factory.
+     * Most HTTP-backed engines (OkHttpDataSourceFactory, CronetDataSource.Factory) also implement
+     * HttpDataSource.Factory, so the typical case works. The instanceof guard protects against
+     * resolvers that return a non-HTTP-typed factory and logs a warning so host apps can detect
+     * the mismatch.
+     */
+    public static HttpDataSource.Factory getHttpDataSourceFactory(ReactContext context, DefaultBandwidthMeter bandwidthMeter, Map<String, String> requestHeaders, String httpEngine) {
+        if (httpEngine != null && httpEngineFactoryResolver != null) {
+            DataSource.Factory factory = httpEngineFactoryResolver.apply(httpEngine);
+            if (factory instanceof HttpDataSource.Factory) {
+                return (HttpDataSource.Factory) factory;
+            }
+            if (factory != null) {
+                Log.w(TAG, "httpEngineFactoryResolver returned a DataSource.Factory that does not implement HttpDataSource.Factory for engine '" + httpEngine + "'; falling back to default HttpDataSource.Factory");
+            }
+        }
+        return getDefaultHttpDataSourceFactory(context, bandwidthMeter, requestHeaders);
+    }
 
     public static DataSource.Factory getDefaultDataSourceFactory(ReactContext context, DefaultBandwidthMeter bandwidthMeter, Map<String, String> requestHeaders) {
         if (defaultDataSourceFactory == null || (requestHeaders != null && !requestHeaders.isEmpty())) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
+
+import java.util.Objects;
 import android.os.Handler;
 import android.os.Message;
 import android.text.TextUtils;
@@ -149,6 +151,7 @@ class ReactExoplayerView extends FrameLayout implements
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
     private Map<String, String> requestHeaders;
+    private String httpEngine;
     private boolean mReportBandwidth = false;
     private UUID drmUUID = null;
     private String drmLicenseUrl = null;
@@ -647,8 +650,8 @@ class ReactExoplayerView extends FrameLayout implements
      * @return A new DataSource factory.
      */
     private DataSource.Factory buildDataSourceFactory(boolean useBandwidthMeter) {
-        return DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext,
-                useBandwidthMeter ? bandwidthMeter : null, requestHeaders);
+        return DataSourceUtil.getDataSourceFactory(this.themedReactContext,
+                useBandwidthMeter ? bandwidthMeter : null, requestHeaders, httpEngine);
     }
 
     /**
@@ -659,7 +662,8 @@ class ReactExoplayerView extends FrameLayout implements
      * @return A new HttpDataSource factory.
      */
     private HttpDataSource.Factory buildHttpDataSourceFactory(boolean useBandwidthMeter) {
-        return DataSourceUtil.getDefaultHttpDataSourceFactory(this.themedReactContext, useBandwidthMeter ? bandwidthMeter : null, requestHeaders);
+        return DataSourceUtil.getHttpDataSourceFactory(this.themedReactContext,
+                useBandwidthMeter ? bandwidthMeter : null, requestHeaders, httpEngine);
     }
 
 
@@ -1039,12 +1043,23 @@ class ReactExoplayerView extends FrameLayout implements
             this.extension = extension;
             this.requestHeaders = headers;
             this.mediaDataSourceFactory =
-                    DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, bandwidthMeter,
-                            this.requestHeaders);
+                    DataSourceUtil.getDataSourceFactory(this.themedReactContext, bandwidthMeter,
+                            this.requestHeaders, this.httpEngine);
 
             if (!isSourceEqual) {
                 reloadSource();
             }
+        }
+    }
+
+    public void setHttpEngine(String httpEngine) {
+        boolean changed = !Objects.equals(this.httpEngine, httpEngine);
+        this.httpEngine = httpEngine;
+        if (changed && srcUri != null) {
+            this.mediaDataSourceFactory =
+                    DataSourceUtil.getDataSourceFactory(this.themedReactContext, bandwidthMeter,
+                            this.requestHeaders, this.httpEngine);
+            reloadSource();
         }
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -71,6 +71,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
+    private static final String PROP_HTTP_ENGINE = "httpEngine";
 
     private ReactExoplayerConfig config;
 
@@ -180,6 +181,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
                 }
             }
         }
+    }
+
+    @ReactProp(name = PROP_HTTP_ENGINE)
+    public void setHttpEngine(final ReactExoplayerView videoView, @Nullable final String httpEngine) {
+        videoView.setHttpEngine(httpEngine);
     }
 
     @ReactProp(name = PROP_RESIZE_MODE)


### PR DESCRIPTION
Allow the host app to register a factory-resolver function via DataSourceUtil.setHttpEngineFactoryResolver() and select the HTTP engine per video instance using the httpEngine React prop. This enables A/B testing of Default, OkHttp, and Cronet engines without introducing circular Gradle dependencies.