### PR TITLE
fix video when resuming from background, guard audio focus when muted to help with multiple video preview footgun

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -474,6 +474,13 @@ Video.propTypes = {
   playWhenInactive: PropTypes.bool,
   ignoreSilentSwitch: PropTypes.oneOf(['ignore', 'obey']),
   reportBandwidth: PropTypes.bool,
+
+  /**
+   * Android only. Skip the audio focus request on play. Required when multiple
+   * <Video> instances need to play concurrently — even when muted, the default
+   * AUDIOFOCUS_GAIN request is denied for subsequent instances, leaving them
+   * silently paused at frame 0 with no onError.
+   */
   disableFocus: PropTypes.bool,
   controls: PropTypes.bool,
   audioOnly: PropTypes.bool,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -85,7 +85,10 @@ public final class ExoPlayerView extends FrameLayout {
         addViewInLayout(layout, 0, aspectRatioParams);
     }
 
-    private void clearVideoView() {
+    void clearVideoView() {
+        if (player == null) {
+            return;
+        }
         if (surfaceView instanceof TextureView) {
             player.clearVideoTextureView((TextureView) surfaceView);
         } else if (surfaceView instanceof SurfaceView) {
@@ -93,7 +96,10 @@ public final class ExoPlayerView extends FrameLayout {
         }
     }
 
-    private void setVideoView() {
+    void setVideoView() {
+        if (player == null) {
+            return;
+        }
         if (surfaceView instanceof TextureView) {
             player.setVideoTextureView((TextureView) surfaceView);
         } else if (surfaceView instanceof SurfaceView) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -555,6 +555,9 @@ class ReactExoplayerView extends FrameLayout implements
             ReactExoplayerView self = this;
             player.removeListener(self);
             trackSelector = null;
+            if (exoPlayerView != null) {
+                exoPlayerView.setPlayer(null);
+            }
             player = null;
         }
         progressHandler.removeMessages(SHOW_PROGRESS);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -247,11 +247,11 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onHostResume() {
-        if (!playInBackground || !isInBackground) {
-            setPlayWhenReady(!isPaused);
-        }
         if (!playInBackground && player != null && exoPlayerView != null) {
             exoPlayerView.setVideoView();
+            if (player.getPlaybackState() == Player.STATE_IDLE) {
+                restoreSourceAfterBackground();
+            }
         }
         isInBackground = false;
     }
@@ -265,7 +265,9 @@ class ReactExoplayerView extends FrameLayout implements
         setPlayWhenReady(false);
         if (player != null) {
             try {
+                updateResumePosition();
                 player.stop();
+                playerNeedsSource = true;
             } catch (Exception e) {
                 // Ignore stop errors
             }
@@ -469,6 +471,38 @@ class ReactExoplayerView extends FrameLayout implements
                 applyModifiers();
             }
         }, 1);
+    }
+
+    // Re-prepare the existing player after a background-induced player.stop() without
+    // firing loadStart/load events, so the JS state machine doesn't think this is a
+    // fresh load. Mirrors the prepare branch of initializePlayer().
+    private void restoreSourceAfterBackground() {
+        if (player == null || srcUri == null || !playerNeedsSource) {
+            return;
+        }
+        exoPlayerView.invalidateAspectRatio();
+
+        ArrayList<MediaSource> mediaSourceList = buildTextSources();
+        MediaSource videoSource = buildMediaSource(srcUri, extension);
+        MediaSource mediaSource;
+        if (mediaSourceList.size() == 0) {
+            mediaSource = videoSource;
+        } else {
+            mediaSourceList.add(0, videoSource);
+            MediaSource[] textSourceArray = mediaSourceList.toArray(
+                    new MediaSource[mediaSourceList.size()]
+            );
+            mediaSource = new MergingMediaSource(textSourceArray);
+        }
+
+        boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
+        if (haveResumePosition) {
+            player.seekTo(resumeWindow, resumePosition);
+        }
+        player.prepare(mediaSource, !haveResumePosition, false);
+        playerNeedsSource = false;
+
+        reLayout(exoPlayerView);
     }
 
     private MediaSource buildMediaSource(Uri uri, String overrideExtension) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -250,6 +250,9 @@ class ReactExoplayerView extends FrameLayout implements
         if (!playInBackground || !isInBackground) {
             setPlayWhenReady(!isPaused);
         }
+        if (!playInBackground && player != null && exoPlayerView != null) {
+            exoPlayerView.setVideoView();
+        }
         isInBackground = false;
     }
 
@@ -266,6 +269,9 @@ class ReactExoplayerView extends FrameLayout implements
             } catch (Exception e) {
                 // Ignore stop errors
             }
+        }
+        if (exoPlayerView != null) {
+            exoPlayerView.clearVideoView();
         }
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -600,8 +600,22 @@ class ReactExoplayerView extends FrameLayout implements
         bandwidthMeter.removeEventListener(this);
     }
 
+    /**
+     * Requests {@link AudioManager#AUDIOFOCUS_GAIN} on {@link AudioManager#STREAM_MUSIC} when this
+     * view may play audible media and participates in focus management.
+     * <p>
+     * Requesting focus while muted is contradictory: there is no audible output, yet
+     * {@code AUDIOFOCUS_GAIN} still participates in global focus semantics. Doing so used to be a
+     * footgun for consumers: several muted players would still contend for focus, so only one could
+     * preview or advance playback at a time. Skipping the {@link AudioManager} call when
+     * {@link #muted} avoids that.
+     *
+     * @return {@code true} if no system call was needed or if focus was granted; {@code false} if
+     *         a request was issued and denied.
+     */
     private boolean requestAudioFocus() {
-        if (disableFocus || srcUri == null || this.hasAudioFocus) {
+        // Skip AudioManager: focus disabled, muted, no source yet, or already focused.
+        if (disableFocus || muted || srcUri == null || this.hasAudioFocus) {
             return true;
         }
         int result = audioManager.requestAudioFocus(this,
@@ -1303,11 +1317,35 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setMutedModifier(boolean muted) {
+        boolean wasMuted = this.muted;
         this.muted = muted;
         audioVolume = muted ? 0.f : 1.f;
-        if (player != null) {
-            player.setVolume(audioVolume);
+
+        if (player == null) {
+            // no player, nothing to do
+            return;
         }
+        
+        player.setVolume(audioVolume);
+
+        // No mute transition, playback not intended (playWhenReady), or focus disabled.
+        if (wasMuted == muted || !player.getPlayWhenReady() || disableFocus) {
+            return;
+        }
+
+        // Otherwise: mute changed during intended playback — sync focus with audible output.
+        if (muted && hasAudioFocus) {
+            // Muted: release focus so other apps can use it.
+            audioManager.abandonAudioFocus(this);
+            this.hasAudioFocus = false;
+            return;
+        }
+
+        if (!muted && !this.hasAudioFocus) {
+            // Unmuted: now we need focus.
+            this.hasAudioFocus = requestAudioFocus();
+        }
+        // Fallthrough — muted with no focus to abandon, or unmuted with focus already held.
     }
 
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -252,6 +252,10 @@ class ReactExoplayerView extends FrameLayout implements
             if (player.getPlaybackState() == Player.STATE_IDLE) {
                 restoreSourceAfterBackground();
             }
+            // Without this, playback stays paused after resume because onHostPause()
+            // set player.playWhenReady=false. setPlayWhenReady() flips it back on,
+            // and reacquires audio focus along the way (skipped when muted).
+            setPlayWhenReady(!isPaused);
         }
         isInBackground = false;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -272,6 +272,11 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
 
     @ReactProp(name = PROP_SEEK)
     public void setSeek(final ReactExoplayerView videoView, final float seek) {
+
+        // this dedupe was applied in PR #4 to handle Fabric firing spurious additional seeks
+        // however this logic is not entirely correct as seeking to the same time over and over simply won't work
+        // (e.g. seeking to time 0 more than once is not uncommon)
+        // upstream consumers have a workaround sitting on top of this dedupe until this gets a full fix. 
         if (seek != lastSeekPosition) {
             lastSeekPosition = seek;
             videoView.seekTo(Math.round(seek * 1000f));


### PR DESCRIPTION
## Summary

Two related Android playback fixes plus some discoverability follow-ups.

### 1. Restore video correctly when the app returns from background

Returning from background could leave a `<Video>` in a broken state (black surface, no playback). `onHostPause` was only pausing the player, which left codec/surface state ExoPlayer couldn't always recover from on resume.

New behavior:
- `onHostPause`: capture resume position, `stop()` the player, mark `playerNeedsSource = true`, and detach the surface from the player view.
- `onHostResume`: re-attach the surface; if the player is in `STATE_IDLE`, re-prepare the source via a new `restoreSourceAfterBackground()` that mirrors the prepare branch of `initializePlayer` *without* firing `loadStart`/`load` (so JS state machines don't see this as a fresh load).
- `releasePlayer`: also detaches the player from the view, preventing dangling references.
- `ExoPlayerView.setVideoView()` / `clearVideoView()`: null-guarded and promoted to package-private so `ReactExoplayerView` can call them during the resume sequence.

### 2. Skip the audio focus request when the player is muted

Every `<Video>` was requesting `AUDIOFOCUS_GAIN` on play regardless of mute state. That's contradictory — a muted player produces no audio — and it's a silent footgun for any consumer rendering multiple muted players concurrently (carousels, feeds, etc.). Only the first instance acquires focus; subsequent instances are denied, and the native code's `setPlayWhenReady` path silently no-ops on a denied focus request. The result: those `<Video>`s render exactly one frame (enough to fire `onReadyForDisplay`) and then sit at frame 0 forever with no `onError`.

New behavior:
- `requestAudioFocus()`: short-circuits when `muted` is true (alongside the existing `disableFocus` check). Muted players never participate in system audio focus.
- `setMutedModifier()`: keeps focus state consistent with audible output across mute toggles during playback — unmute while playing acquires focus, mute while playing releases it. `disableFocus` continues to win.

### 3. Docstring on the `disableFocus` prop

The escape hatch to suppress audio focus has been around for a long time but was undocumented; the prop name describes the mechanism, not when you'd want it. Added a JSDoc explaining the multi-`<Video>`-on-Android case and the silent-frame-0 symptom. Strictly redundant for muted players once (2) lands, but still applies to concurrent playback of unmuted Videos.

### 4. Drive-by comment on the seek dedupe

Documents the known limitation of the existing dedupe in `setSeek` (originally added in #4 for Fabric) — repeated seeks to the same time silently no-op, which surprises consumers; upstream consumers carry a workaround on top of this for now.

## Test plan

**Background restore:**
- Open a screen with a `<Video>` actively playing.
- Background the app for ~10s, return.
- Video resumes cleanly — no black surface, no `loadStart`/`load` re-fire on JS.

**Muted audio focus:**
- Render two muted `<Video>` instances side by side on Android (`muted={true}`, no `disableFocus`).
- Both should preview/play simultaneously. (Pre-fix: only the first advances; the second freezes at frame 0 with no `onError`.)
- Mute toggle mid-playback: start muted → toggle `muted={false}` while playing → audio starts; toggle back → audio stops and focus is released.

Asana: https://app.asana.com/1/236888843494340/project/1210587513679172/task/1214266202608004