### PR TITLE
fix queue drain race condition

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -245,10 +245,17 @@ static int const RCTVideoUnset = -1;
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+  // Hold an explicit ref so the AVPlayer stays alive across the observer
+  // removal and queue drain, even if some path nilled _player concurrently.
+  // The local releases at scope end, on main (UIView dealloc runs on main),
+  // guaranteeing the AVPlayer is never released on _progressQueue.
+  AVPlayer *retainedPlayer = _player;
+  [self removePlayerTimeObserver];
   [self removePlayerLayer];
   [self removePlayerItemObservers];
   [_player removeObserver:self forKeyPath:playbackRate context:nil];
   [_player removeObserver:self forKeyPath:externalPlaybackActive context: nil];
+  (void)retainedPlayer;
 }
 
 #pragma mark - App lifecycle handlers

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -208,10 +208,20 @@ static int const RCTVideoUnset = -1;
     queue = _progressQueue;
   }
   __weak RCTVideo *weakSelf = self;
+  // Weak-capture the player so the block can atomically load it via
+  // objc_loadWeakRetained. Strong ivar reads (self->_player) are not atomic
+  // w.r.t. concurrent release, so even a strong-local snapshot inside the
+  // block is racy. A weak load returns nil if the AVPlayer is being
+  // deallocated; otherwise it keeps the player alive for the call.
+  __weak AVPlayer *weakPlayer = _player;
   _timeObserver = [_player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(progressUpdateIntervalMS, NSEC_PER_SEC)
                                                         queue:queue
-                                                   usingBlock:^(CMTime time) { [weakSelf sendProgressUpdate]; }
-                   ];
+                                                   usingBlock:^(CMTime time) {
+    RCTVideo *strongSelf = weakSelf;
+    AVPlayer *strongPlayer = weakPlayer;
+    if (!strongSelf || !strongPlayer) return;
+    [strongSelf sendProgressUpdateForPlayer:strongPlayer];
+  }];
 }
 
 /* Cancels the previously registered time observer. */
@@ -282,13 +292,8 @@ static int const RCTVideoUnset = -1;
 
 #pragma mark - Progress
 
-- (void)sendProgressUpdate
+- (void)sendProgressUpdateForPlayer:(AVPlayer *)player
 {
-  // Strong snapshot so the player can't be released mid-call from another thread.
-  AVPlayer *player = self->_player;
-  if (player == nil) {
-    return;
-  }
   AVPlayerItem *video = [player currentItem];
   if (video == nil || video.status != AVPlayerItemStatusReadyToPlay) {
     return;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -17,9 +17,8 @@ static NSString *const externalPlaybackActive = @"externalPlaybackActive";
 
 static int const RCTVideoUnset = -1;
 
-// Identity key for _progressQueue. Use the address of the static itself as
-// both the key and the value so dispatch_get_specific returns a recognizable
-// sentinel when the current thread is executing on _progressQueue.
+// Self-referential sentinel: dispatch_get_specific returns this iff the
+// current thread is executing on _progressQueue.
 static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey;
 
 #ifdef DEBUG
@@ -203,31 +202,21 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
 
   dispatch_queue_t queue = NULL;
   if ([RNVVideoManager useBackgroundProgressQueue]) {
-    // Use a background queue so sendProgressUpdate can call AVPlayer/AVPlayerItem
-    // methods (e.g. currentDate) that may block on internal dispatch_sync without
-    // stalling the main thread. removePlayerTimeObserver drains this queue during
-    // teardown so no block can run against a released player.
+    // Off-main so sendProgressUpdate can call AVPlayer methods that
+    // dispatch_sync internally (e.g. currentDate) without stalling main.
     if (!_progressQueue) {
       _progressQueue = dispatch_queue_create("com.discord.react-native-video.progress", DISPATCH_QUEUE_SERIAL);
-      // Tag the queue so removePlayerTimeObserver can detect re-entrant calls
-      // (which would deadlock the dispatch_sync drain) and skip the drain.
       dispatch_queue_set_specific(_progressQueue, kProgressQueueSpecificKey,
                                   (void *)kProgressQueueSpecificKey, NULL);
     }
     queue = _progressQueue;
   }
-  // Invariant: nothing dispatched onto _progressQueue may strong-capture self.
-  // The teardown path (removeFromSuperview/dealloc) calls dispatch_sync on
-  // _progressQueue, which would deadlock if dealloc itself landed on
-  // _progressQueue (i.e., the queue held the last strong ref to self). Today
-  // both the periodic observer block and the deliverProgress block use
-  // weakSelf; preserve that.
+  // Invariant: blocks dispatched onto _progressQueue must not strong-capture
+  // self or _player. Teardown dispatch_syncs into _progressQueue to drain;
+  // a strong capture could land dealloc on the queue and self-deadlock.
+  // Weak _player additionally closes the non-atomic strong-ivar-read race
+  // against concurrent _player = nil on main.
   __weak RCTVideo *weakSelf = self;
-  // Weak-capture the player so the block can atomically load it via
-  // objc_loadWeakRetained. Strong ivar reads (self->_player) are not atomic
-  // w.r.t. concurrent release, so even a strong-local snapshot inside the
-  // block is racy. A weak load returns nil if the AVPlayer is being
-  // deallocated; otherwise it keeps the player alive for the call.
   __weak AVPlayer *weakPlayer = _player;
   _timeObserver = [_player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(progressUpdateIntervalMS, NSEC_PER_SEC)
                                                         queue:queue
@@ -246,12 +235,9 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
   {
     [_player removeTimeObserver:_timeObserver];
     _timeObserver = nil;
-    // removeTimeObserver: does not wait for blocks already dispatched to the
-    // observer queue. Drain the queue so any in-flight sendProgressUpdate
-    // completes before the caller releases _player. Skip the drain if we are
-    // already on _progressQueue (e.g., a notification handler delivered there
-    // somehow re-enters teardown) — dispatch_sync onto the current queue
-    // would self-deadlock.
+    // removeTimeObserver: doesn't wait for already-dispatched blocks; drain
+    // so an in-flight sendProgressUpdate can't outlive the caller releasing
+    // _player. Skip if re-entered from _progressQueue (would self-deadlock).
     if (_progressQueue &&
         dispatch_get_specific(kProgressQueueSpecificKey) != kProgressQueueSpecificKey) {
       dispatch_sync(_progressQueue, ^{});
@@ -264,14 +250,9 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-  // Hold an explicit ref so the AVPlayer stays alive across the observer
-  // removal and queue drain, even if some path nilled _player concurrently.
-  // NS_VALID_UNTIL_END_OF_SCOPE opts the local into precise lifetime — without
-  // it ARC may release the local after its last syntactic use, defeating the
-  // purpose. UIView dealloc conventionally runs on main, in which case the
-  // final release of the player also lands on main; if dealloc lands on a
-  // background thread the queue-specific guard in removePlayerTimeObserver
-  // still prevents a self-deadlock on the drain.
+  // Keep the player alive across the observer removal and queue drain. ARC
+  // is allowed to release a __strong local after its last use, so precise
+  // lifetime is required — a trailing (void)x cast does not count as a use.
   NS_VALID_UNTIL_END_OF_SCOPE AVPlayer *retainedPlayer = _player;
   [self removePlayerTimeObserver];
   [self removePlayerLayer];
@@ -1709,8 +1690,7 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
 - (void)removeFromSuperview
 {
   [_player pause];
-  // Must run before _player is released so [_player removeTimeObserver:] is
-  // effective and the progress queue can be drained while the player is alive.
+  // Must precede _player = nil below; otherwise removeTimeObserver: is a no-op.
   [self removePlayerTimeObserver];
   if (_playbackRateObserverRegistered) {
     [_player removeObserver:self forKeyPath:playbackRate context:nil];

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -200,8 +200,8 @@ static int const RCTVideoUnset = -1;
   if ([RNVVideoManager useBackgroundProgressQueue]) {
     // Use a background queue so sendProgressUpdate can call AVPlayer/AVPlayerItem
     // methods (e.g. currentDate) that may block on internal dispatch_sync without
-    // stalling the main thread. This is safe because removePlayerTimeObserver
-    // (called during teardown) guarantees no further callbacks after it returns.
+    // stalling the main thread. removePlayerTimeObserver drains this queue during
+    // teardown so no block can run against a released player.
     if (!_progressQueue) {
       _progressQueue = dispatch_queue_create("com.discord.react-native-video.progress", DISPATCH_QUEUE_SERIAL);
     }
@@ -221,6 +221,12 @@ static int const RCTVideoUnset = -1;
   {
     [_player removeTimeObserver:_timeObserver];
     _timeObserver = nil;
+    // removeTimeObserver: does not wait for blocks already dispatched to the
+    // observer queue. Drain the queue so any in-flight sendProgressUpdate
+    // completes before the caller releases _player.
+    if (_progressQueue) {
+      dispatch_sync(_progressQueue, ^{});
+    }
   }
 }
 
@@ -278,7 +284,12 @@ static int const RCTVideoUnset = -1;
 
 - (void)sendProgressUpdate
 {
-  AVPlayerItem *video = [_player currentItem];
+  // Strong snapshot so the player can't be released mid-call from another thread.
+  AVPlayer *player = self->_player;
+  if (player == nil) {
+    return;
+  }
+  AVPlayerItem *video = [player currentItem];
   if (video == nil || video.status != AVPlayerItemStatusReadyToPlay) {
     return;
   }
@@ -288,8 +299,8 @@ static int const RCTVideoUnset = -1;
     return;
   }
 
-  CMTime currentTime = _player.currentTime;
-  NSDate *currentPlaybackTime = _player.currentItem.currentDate;
+  CMTime currentTime = player.currentTime;
+  NSDate *currentPlaybackTime = player.currentItem.currentDate;
   const Float64 duration = CMTimeGetSeconds(playerDuration);
   const Float64 currentTimeSecs = CMTimeGetSeconds(currentTime);
 
@@ -1664,6 +1675,9 @@ static int const RCTVideoUnset = -1;
 - (void)removeFromSuperview
 {
   [_player pause];
+  // Must run before _player is released so [_player removeTimeObserver:] is
+  // effective and the progress queue can be drained while the player is alive.
+  [self removePlayerTimeObserver];
   if (_playbackRateObserverRegistered) {
     [_player removeObserver:self forKeyPath:playbackRate context:nil];
     _playbackRateObserverRegistered = NO;
@@ -1673,17 +1687,16 @@ static int const RCTVideoUnset = -1;
     _isExternalPlaybackActiveObserverRegistered = NO;
   }
   _player = nil;
-  
+
   [self removePlayerLayer];
-  
+
   [_playerViewController.contentOverlayView removeObserver:self forKeyPath:@"frame"];
   [_playerViewController removeObserver:self forKeyPath:readyForDisplayKeyPath];
   [_playerViewController.view removeFromSuperview];
   _playerViewController.rctDelegate = nil;
   _playerViewController.player = nil;
   _playerViewController = nil;
-  
-  [self removePlayerTimeObserver];
+
   [self removePlayerItemObservers];
   
   _eventDispatcher = nil;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -17,6 +17,11 @@ static NSString *const externalPlaybackActive = @"externalPlaybackActive";
 
 static int const RCTVideoUnset = -1;
 
+// Identity key for _progressQueue. Use the address of the static itself as
+// both the key and the value so dispatch_get_specific returns a recognizable
+// sentinel when the current thread is executing on _progressQueue.
+static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey;
+
 #ifdef DEBUG
     #define DebugLog(...) NSLog(__VA_ARGS__)
 #else
@@ -204,9 +209,19 @@ static int const RCTVideoUnset = -1;
     // teardown so no block can run against a released player.
     if (!_progressQueue) {
       _progressQueue = dispatch_queue_create("com.discord.react-native-video.progress", DISPATCH_QUEUE_SERIAL);
+      // Tag the queue so removePlayerTimeObserver can detect re-entrant calls
+      // (which would deadlock the dispatch_sync drain) and skip the drain.
+      dispatch_queue_set_specific(_progressQueue, kProgressQueueSpecificKey,
+                                  (void *)kProgressQueueSpecificKey, NULL);
     }
     queue = _progressQueue;
   }
+  // Invariant: nothing dispatched onto _progressQueue may strong-capture self.
+  // The teardown path (removeFromSuperview/dealloc) calls dispatch_sync on
+  // _progressQueue, which would deadlock if dealloc itself landed on
+  // _progressQueue (i.e., the queue held the last strong ref to self). Today
+  // both the periodic observer block and the deliverProgress block use
+  // weakSelf; preserve that.
   __weak RCTVideo *weakSelf = self;
   // Weak-capture the player so the block can atomically load it via
   // objc_loadWeakRetained. Strong ivar reads (self->_player) are not atomic
@@ -233,8 +248,12 @@ static int const RCTVideoUnset = -1;
     _timeObserver = nil;
     // removeTimeObserver: does not wait for blocks already dispatched to the
     // observer queue. Drain the queue so any in-flight sendProgressUpdate
-    // completes before the caller releases _player.
-    if (_progressQueue) {
+    // completes before the caller releases _player. Skip the drain if we are
+    // already on _progressQueue (e.g., a notification handler delivered there
+    // somehow re-enters teardown) — dispatch_sync onto the current queue
+    // would self-deadlock.
+    if (_progressQueue &&
+        dispatch_get_specific(kProgressQueueSpecificKey) != kProgressQueueSpecificKey) {
       dispatch_sync(_progressQueue, ^{});
     }
   }
@@ -247,15 +266,18 @@ static int const RCTVideoUnset = -1;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   // Hold an explicit ref so the AVPlayer stays alive across the observer
   // removal and queue drain, even if some path nilled _player concurrently.
-  // The local releases at scope end, on main (UIView dealloc runs on main),
-  // guaranteeing the AVPlayer is never released on _progressQueue.
-  AVPlayer *retainedPlayer = _player;
+  // NS_VALID_UNTIL_END_OF_SCOPE opts the local into precise lifetime — without
+  // it ARC may release the local after its last syntactic use, defeating the
+  // purpose. UIView dealloc conventionally runs on main, in which case the
+  // final release of the player also lands on main; if dealloc lands on a
+  // background thread the queue-specific guard in removePlayerTimeObserver
+  // still prevents a self-deadlock on the drain.
+  NS_VALID_UNTIL_END_OF_SCOPE AVPlayer *retainedPlayer = _player;
   [self removePlayerTimeObserver];
   [self removePlayerLayer];
   [self removePlayerItemObservers];
   [_player removeObserver:self forKeyPath:playbackRate context:nil];
   [_player removeObserver:self forKeyPath:externalPlaybackActive context: nil];
-  (void)retainedPlayer;
 }
 
 #pragma mark - App lifecycle handlers


### PR DESCRIPTION
## Summary

Fixes an `EXC_BAD_ACCESS` inside `-[AVPlayer currentItem]` reached from `RCTVideo`'s periodic time observer block running on `_progressQueue`.

Root causes (introduced when the progress observer was moved off main in e3948e0):

- `-[AVPlayer removeTimeObserver:]` does **not** synchronously drain blocks already dispatched to the observer queue. A block could fire on `_progressQueue` after teardown started on main and call `[_player currentItem]` on a partially-deallocated `AVPlayer`.
- In `removeFromSuperview`, `_player = nil` ran **before** `[self removePlayerTimeObserver]`, so `[_player removeTimeObserver:]` was effectively a no-op on that path — the periodic observer survived the teardown call and kept firing while `_playerLayer`/`_playerViewController` released their refs to the player.
- `dealloc` never removed the time observer at all, leaving the bypass path uncovered.

## Changes (all in `ios/Video/RCTVideo.m`)

- `removePlayerTimeObserver`: after `removeTimeObserver:`, `dispatch_sync(_progressQueue, ^{})` to flush any in-flight block before the caller releases `_player`.
- `removeFromSuperview`: call `removePlayerTimeObserver` **before** `_player = nil`.
- Periodic-observer block: weak-capture both `self` and `_player`, then `objc_loadWeakRetained`-snapshot inside. Closes the strong-ivar-read race (ARC strong ivar reads are not atomic w.r.t. concurrent release).
- `sendProgressUpdate` → `sendProgressUpdateForPlayer:` so the method takes the snapshotted `AVPlayer` as a parameter and never touches the ivar.
- `dealloc`: hold an explicit local ref to `_player`, call `removePlayerTimeObserver` (which drains the queue), then release the local at scope end. Covers the path where `removeFromSuperview` doesn't run and guarantees the final `AVPlayer` release lands on main.
- Updated the misleading comment that claimed `removeTimeObserver:` guaranteed no further callbacks.

## Why this is recent

Pre-`e3948e0`, the observer block ran on main, so the teardown and the block couldn't race. The crash window only exists with `[RNVVideoManager useBackgroundProgressQueue]` enabled.

## Test plan

- [ ] Build Discord against this branch; mount a `RCTVideo`, start playback, unmount the view (exercises `removeFromSuperview`).
- [ ] Change the `source` prop mid-playback (exercises `removePlayerTimeObserver` at the source-setter sites).
- [ ] Stress loop: rapid mount/unmount during playback on a real device to attempt to reproduce the pre-fix crash; should no longer reproduce.
- [ ] Monitor crash reports for the `-[AVPlayer currentItem]` / `sendProgressUpdate` signature after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Asana: https://app.asana.com/1/236888843494340/project/1210587513679172/task/1215031301008797

Sentry issue noted here: https://discord.sentry.io/issues/7402829709/?project=230973&query=is%3Aunresolved%20error.handled%3AFalse&referrer=issue-stream&sort=freq

Open thread at: https://discord.com/channels/281683040739262465/1506360618016440471/1507089718687305728