### PR TITLE
fix audioRouteChanged: use-after-free on route change during teardown

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -97,6 +97,7 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
   void (^__strong _Nonnull _restoreUserInterfaceForPIPStopCompletionHandler)(BOOL);
   AVPictureInPictureController *_pipController;
 #endif
+  id _audioRouteChangeObserver;
 }
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
@@ -147,10 +148,20 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
     
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(audioRouteChanged:)
-                                                 name:AVAudioSessionRouteChangeNotification
-                                               object:nil];
+    // Block-based observer with a weak self: AVAudioSessionRouteChangeNotification
+    // is posted by the AudioSession framework via an async dispatch to the main
+    // queue, while this UIView's -dealloc is not guaranteed to run on main.
+    // A selector-based observer is held unsafe-unretained, so a route change in
+    // flight could call out to a freed RCTVideo (EXC_BAD_ACCESS). The center
+    // retains the block instead, and weakSelf resolves to nil once we're gone.
+    __weak __typeof(self) weakSelf = self;
+    _audioRouteChangeObserver =
+        [[NSNotificationCenter defaultCenter] addObserverForName:AVAudioSessionRouteChangeNotification
+                                                          object:nil
+                                                           queue:[NSOperationQueue mainQueue]
+                                                      usingBlock:^(NSNotification *note) {
+      [weakSelf audioRouteChanged:note];
+    }];
   }
   
   return self;
@@ -249,6 +260,10 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
 
 - (void)dealloc
 {
+  if (_audioRouteChangeObserver) {
+    [[NSNotificationCenter defaultCenter] removeObserver:_audioRouteChangeObserver];
+    _audioRouteChangeObserver = nil;
+  }
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   // Keep the player alive across the observer removal and queue drain. ARC
   // is allowed to release a __strong local after its last use, so precise

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -148,12 +148,7 @@ static const void * const kProgressQueueSpecificKey = &kProgressQueueSpecificKey
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
     
-    // Block-based observer with a weak self: AVAudioSessionRouteChangeNotification
-    // is posted by the AudioSession framework via an async dispatch to the main
-    // queue, while this UIView's -dealloc is not guaranteed to run on main.
-    // A selector-based observer is held unsafe-unretained, so a route change in
-    // flight could call out to a freed RCTVideo (EXC_BAD_ACCESS). The center
-    // retains the block instead, and weakSelf resolves to nil once we're gone.
+    // Block-based observer with a weak self avoids a use-after-free on a route change during teardown.
     __weak __typeof(self) weakSelf = self;
     _audioRouteChangeObserver =
         [[NSNotificationCenter defaultCenter] addObserverForName:AVAudioSessionRouteChangeNotification


### PR DESCRIPTION
Saw this crash while looking at another one in sentry, doing a drive by fix.

==========================

AVAudioSessionRouteChangeNotification is posted by the AudioSession framework via an async dispatch to the main queue, while RCTVideo is a UIView whose -dealloc is not guaranteed to run on main. The selector- based observer was held unsafe-unretained, so a route change already in flight on the main queue could call out to a freed RCTVideo and crash with EXC_BAD_ACCESS (KERN_INVALID_ADDRESS) inside audioRouteChanged:. removeObserver:self in dealloc can't close the window because the post is already enqueued on another thread.

Register the route-change observer with the block-based API capturing a weak self: the center retains the block (no dangling unretained pointer), and weakSelf resolves to nil once the view is gone, so a late or racing callout safely no-ops. Store the token and remove it in dealloc.

Asana: https://app.asana.com/1/236888843494340/project/1210587513679172/task/1215639553522632